### PR TITLE
GUI requirements optional

### DIFF
--- a/.github/workflows/new_release.yml
+++ b/.github/workflows/new_release.yml
@@ -19,6 +19,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install -r requirements_gui.txt
           mkdir models
           cd models
           curl.exe -o renal_segmentor.model https://zenodo.org/record/4894406/files/whole_kidney_cnn.model

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -34,6 +34,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest pytest-cov codecov wheel
         pip install -r requirements.txt
+        pip install -r requirements_gui.txt
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Alternatively, the methods used by the segmentor are available as a Python packa
 2. Run the `renal_segmentor.exe -h` to generate a list of available parameters. The application runs via a command line if any input arguments are specified, if not, it opens as a GUI.
 
 ### As a Python package
-1. Activate the python environment you want to install the package on and run `pip install renalsegmentor`.
+1. Activate the python environment you want to install the package on and run `pip install renalsegmentor`. If you want to install the additional dependencies required for the GUI, run `pip install renalsegmentor[gui]` however to use the segmentor as a python package, these are not required.
 2. The example code snippet below will generate a mask of `T2w.nii.gz` as a numpy array and print the TKV to the terminal.
 
 ```python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
-Gooey==1.0.8.1
 nibabel==3.2.1
 numpy==1.21.5
 pandas==1.3.5
-pyinstaller==4.7
 pytest==6.2.5
 scikit-image==0.19.1
 tensorflow==2.7.0

--- a/requirements_gui.txt
+++ b/requirements_gui.txt
@@ -1,0 +1,2 @@
+Gooey==1.0.8.1
+pyinstaller==4.7

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,9 @@ from setuptools import setup, find_packages
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()
 
+with open('requirements_gui.txt') as f:
+    requirements_gui = f.read().splitlines()
+
 with open('README.md', encoding='utf-8') as f:
     long_description = f.read()
 
@@ -18,9 +21,8 @@ setup(
     python_requires='>=3.7, <4',
     packages=find_packages(),
     install_requires=requirements,
+    extras_require={'gui': [requirements_gui]},
     include_package_data=True,
-
-
     classifiers=[
         'Development Status :: 5 - Production/Stable',
 


### PR DESCRIPTION
Installing wxPython takes forever on linux, therefore GUI requirements are now optional, they can be installed through `pip install renal_segmentor[gui]`.