### PR TITLE
rel/v1.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.3.7] - 2023-06-23
+
+### Changed
+* Lots of dependencies
+
+
 ## [1.3.6] - 2023-02-16
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ authors:
   given-names: "Susan T"
   orcid: "https://orcid.org/0000-0003-0903-7507"
 title: "Renal Segmentor"
-version: 1.3.6
+version: 1.3.7
 doi: 10.5281/zenodo.5796277
-date-released: 2023-02-16
+date-released: 2023-06-23
 url: "https://github.com/alexdaniel654/Renal_Segmentor"

--- a/renal_segmentor.py
+++ b/renal_segmentor.py
@@ -114,7 +114,7 @@ if len(sys.argv) >= 2:
                 'name': 'Renal Segmentor',
                 'description': 'Automatically segment the kidneys from MRI '
                                'data.',
-                'version': '1.3.6',
+                'version': '1.3.7',
                 'copyright': '2023',
                 'website': 'https://github.com/alexdaniel654/Renal_Segmentor',
                 'developer': 'https://www.researchgate.net/profile/'

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.md', encoding='utf-8') as f:
 
 setup(
     name="renalsegmentor",
-    version="1.3.6",
+    version="1.3.7",
     description="Segment kidneys from MRI data",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
v1.3.7 release. Mainly happening so I can bump skimage to v0.20 so there aren't any compatibility issues with UKAT where v0.20 is needed.